### PR TITLE
Enforce coverage thresholds in PR gate

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -223,7 +223,7 @@ jobs:
             echo "| --- | --- | --- |"
             echo "| Lint | \`npm run lint\` | ${{ needs.lint.result }} |"
             echo "| Unit/component tests | \`npm test -- --run\` | ${{ needs.unit.result }} |"
-            echo "| Coverage | \`npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary\` | ${{ needs.coverage.result }} |"
+            echo "| Coverage | \`npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary\`<br>Thresholds: lines 90%, statements 90%, functions 90%, branches 80% | ${{ needs.coverage.result }} |"
             echo "| Production build | \`npm run build\` | ${{ needs.build.result }} |"
             echo "| End-to-end tests | \`npm run test:e2e\` | ${{ needs.e2e.result }} |"
             echo ""

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -166,7 +166,7 @@ export function CollectionPage() {
 
 Conventional Commits — `feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `chore:`. Never run `git commit` or `git push` unless explicitly asked. When the user explicitly asks Codex to commit and push, treat that as approval that the pre-commit review gate is satisfied unless the user says otherwise.
 
-Routine development happens on topic branches and merges to `master` through pull requests. Direct pushes to `master` are reserved for emergencies. Pull requests must pass the required `required / quality gate` check from the PR Quality Gate workflow before merge. That aggregate job depends on visible lint, unit/component test, coverage, production build, and Playwright E2E jobs, then posts the PR report and fails if any upstream job did not succeed. GitHub-native secret scanning and push protection are the secret leak controls for this repo; do not add a third-party secret scanner unless the workflow is intentionally revised.
+Routine development happens on topic branches and merges to `master` through pull requests. Direct pushes to `master` are reserved for emergencies. Before committing or opening a PR, check the current branch and make sure it is a fresh, purpose-specific branch for the current work, not an old branch that has already merged or belongs to another PR. When in doubt, refresh `origin/master` and create a new branch from it before committing. Pull requests must pass the required `required / quality gate` check from the PR Quality Gate workflow before merge. That aggregate job depends on visible lint, unit/component test, coverage, production build, and Playwright E2E jobs, then posts the PR report and fails if any upstream job did not succeed. GitHub-native secret scanning and push protection are the secret leak controls for this repo; do not add a third-party secret scanner unless the workflow is intentionally revised.
 
 GitHub Issues are used for task tracking. Before implementation, check for an existing issue or create/draft one unless the change is truly tiny. Use `Refs #N` or `Closes #N` in commit messages when useful.
 
@@ -214,6 +214,12 @@ Treat the workflow itself as improvable. If a task reveals unclear issue criteri
 **Bug fixes must include a regression test.** The test documents the invariant and prevents the same issue from reappearing silently.
 
 Tests are co-located in `__tests__/` folders. Use `vi.useFakeTimers()` / `vi.advanceTimersByTime()` for timer-dependent logic. Use `renderHook` from RTL for hook tests.
+
+### Coverage
+
+`npm run test:coverage` enforces global Vitest thresholds of 90% lines, 90% statements, 90% functions, and 80% branches. The branch threshold is lower because UI and parser code naturally accumulates defensive and platform-specific branches, but new branch-heavy logic should still include focused tests for its meaningful paths instead of relying on the global total.
+
+Coverage excludes static collection JSON and generated route-tree code. These files are validated through data/schema or router-generation workflows rather than executable coverage, and counting them would make the coverage signal noisier. Do not exclude low-coverage files only to raise totals when they contain real behavior; add focused tests or document why the file is a thin runtime wrapper.
 
 ### Unit Test Standard
 

--- a/scripts/__tests__/build-lib.test.mjs
+++ b/scripts/__tests__/build-lib.test.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getWranglerLogPath } from '../build-lib.mjs'
+import { getWranglerLogPath, runCommand } from '../build-lib.mjs'
 
 describe('build tooling', () => {
     it('defaults Wrangler logs to a project-local cache directory', () => {
@@ -12,6 +12,16 @@ describe('build tooling', () => {
     it('respects an explicit Wrangler log path', () => {
         expect(getWranglerLogPath({ WRANGLER_LOG_PATH: '.wrangler/logs' }, '/workspace/langtype')).toBe(
             '.wrangler/logs'
+        )
+    })
+
+    it('resolves when a spawned command exits successfully', async () => {
+        await expect(runCommand(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' })).resolves.toBeUndefined()
+    })
+
+    it('rejects when a spawned command exits unsuccessfully', async () => {
+        await expect(runCommand(process.execPath, ['-e', 'process.exit(7)'], { stdio: 'ignore' })).rejects.toThrow(
+            `${process.execPath} -e process.exit(7) exited with code 7`
         )
     })
 })

--- a/scripts/github/__tests__/comment-ci-report.test.mjs
+++ b/scripts/github/__tests__/comment-ci-report.test.mjs
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildComment } from '../comment-ci-report.mjs'
+
+const originalCwd = process.cwd()
+let tempDir
+
+describe('CI report comment', () => {
+    beforeEach(async () => {
+        tempDir = await mkdtemp(path.join(os.tmpdir(), 'langtype-ci-report-'))
+        process.chdir(tempDir)
+        process.env.LINT_OUTCOME = 'success'
+        process.env.UNIT_OUTCOME = 'success'
+        process.env.COVERAGE_OUTCOME = 'failure'
+        process.env.BUILD_OUTCOME = 'success'
+        process.env.E2E_OUTCOME = 'success'
+
+        await mkdir('coverage', { recursive: true })
+        await writeFile('coverage/coverage-summary.json', JSON.stringify({
+            total: {
+                lines: { pct: 91 },
+                statements: { pct: 92 },
+                functions: { pct: 93 },
+                branches: { pct: 81 },
+            },
+            '/repo/src/example.ts': {
+                lines: { pct: 91 },
+                statements: { pct: 92 },
+                functions: { pct: 93 },
+                branches: { pct: 81 },
+            },
+        }))
+    })
+
+    afterEach(async () => {
+        process.chdir(originalCwd)
+        delete process.env.LINT_OUTCOME
+        delete process.env.UNIT_OUTCOME
+        delete process.env.COVERAGE_OUTCOME
+        delete process.env.BUILD_OUTCOME
+        delete process.env.E2E_OUTCOME
+        await rm(tempDir, { recursive: true, force: true })
+    })
+
+    it('shows coverage thresholds and threshold failure guidance', () => {
+        const comment = buildComment({
+            serverUrl: 'https://github.com',
+            repository: 'owner/repo',
+            runId: '123',
+        })
+
+        expect(comment).toContain('| Coverage | fail | failed job may be from tests or threshold enforcement; see artifacts for details; see coverage tables below |')
+        expect(comment).toContain('| Metric | Total | Threshold |')
+        expect(comment).toContain('| Lines | 91.00% | 90% |')
+        expect(comment).toContain('| Statements | 92.00% | 90% |')
+        expect(comment).toContain('| Functions | 93.00% | 90% |')
+        expect(comment).toContain('| Branches | 81.00% | 80% |')
+        expect(comment).toContain('failed job may be from tests or threshold enforcement')
+    })
+})

--- a/scripts/github/comment-ci-report.mjs
+++ b/scripts/github/comment-ci-report.mjs
@@ -1,15 +1,24 @@
 import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 const MARKER = '<!-- langtype-ci-report -->'
 const MAX_FAILURES = 10
 const ARTIFACTS_DIR = process.env.CI_ARTIFACTS_DIR ?? 'artifacts'
+const COVERAGE_THRESHOLDS = {
+    lines: 90,
+    statements: 90,
+    functions: 90,
+    branches: 80,
+}
 
 const env = process.env
 
-main().catch((error) => {
-    console.error(error)
-    process.exit(1)
-})
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+    main().catch((error) => {
+        console.error(error)
+        process.exit(1)
+    })
+}
 
 async function main() {
     const context = getContext()
@@ -51,11 +60,20 @@ function getContext() {
     }
 }
 
-function buildComment(context) {
+export function buildComment(context) {
     const vitest = parseVitest()
     const coverage = parseCoverage()
     const playwright = parsePlaywright()
     const runUrl = `${context.serverUrl}/${context.repository}/actions/runs/${context.runId}`
+    const coverageDetails = coverage.totals
+        ? [
+            coverageFailureNote(),
+            'see coverage tables below',
+        ].filter(Boolean).join('; ')
+        : [
+            coverage.summary,
+            coverageFailureNote(),
+        ].filter(Boolean).join('; ')
     const lines = [
         MARKER,
         '## PR Quality Gate report',
@@ -64,7 +82,7 @@ function buildComment(context) {
         '| --- | --- | --- |',
         `| Lint | ${formatOutcome(env.LINT_OUTCOME)} | \`npm run lint\` |`,
         `| Unit/component tests | ${formatOutcome(env.UNIT_OUTCOME)} | ${escapeCell(vitest.summary)} |`,
-        `| Coverage | ${formatOutcome(env.COVERAGE_OUTCOME)} | ${escapeCell(coverage.summary)}; see table below |`,
+        `| Coverage | ${formatOutcome(env.COVERAGE_OUTCOME)} | ${escapeCell(coverageDetails)} |`,
         `| Production build | ${formatOutcome(env.BUILD_OUTCOME)} | \`npm run build\` |`,
         `| End-to-end tests | ${formatOutcome(env.E2E_OUTCOME)} | ${escapeCell(playwright.summary)} |`,
         '',
@@ -129,7 +147,8 @@ function parseCoverage() {
     }
 
     return {
-        summary: formatCoverageSummary(total),
+        summary: 'Coverage totals and thresholds reported below.',
+        totals: formatCoverageTotals(total),
         rows: buildCoverageRows(report),
     }
 }
@@ -208,7 +227,18 @@ function addFailures(lines, title, failures) {
 }
 
 function addCoverageTable(lines, coverage) {
-    if (coverage.rows.length === 0) return
+    if (!coverage.totals || coverage.rows.length === 0) return
+
+    lines.push(
+        '',
+        '### Coverage totals',
+        '',
+        '| Metric | Total | Threshold |',
+        '| --- | ---: | ---: |',
+    )
+    lines.push(...coverage.totals.map((row) => {
+        return `| ${row.metric} | ${row.total} | ${row.threshold} |`
+    }))
 
     lines.push(
         '',
@@ -246,13 +276,22 @@ function formatCoverageRow(file, metrics) {
     }
 }
 
-function formatCoverageSummary(total) {
+function formatCoverageTotals(total) {
     return [
-        `lines ${formatPercent(total.lines?.pct)}`,
-        `statements ${formatPercent(total.statements?.pct)}`,
-        `functions ${formatPercent(total.functions?.pct)}`,
-        `branches ${formatPercent(total.branches?.pct)}`,
-    ].join(', ')
+        { metric: 'Lines', total: formatPercent(total.lines?.pct), threshold: formatThreshold('lines') },
+        { metric: 'Statements', total: formatPercent(total.statements?.pct), threshold: formatThreshold('statements') },
+        { metric: 'Functions', total: formatPercent(total.functions?.pct), threshold: formatThreshold('functions') },
+        { metric: 'Branches', total: formatPercent(total.branches?.pct), threshold: formatThreshold('branches') },
+    ]
+}
+
+function formatThreshold(metric) {
+    return `${COVERAGE_THRESHOLDS[metric]}%`
+}
+
+function coverageFailureNote() {
+    if (env.COVERAGE_OUTCOME !== 'failure') return ''
+    return 'failed job may be from tests or threshold enforcement; see artifacts for details'
 }
 
 function formatOutcome(outcome) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { coverageConfigDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
@@ -9,6 +9,20 @@ export default defineConfig({
         globals: true,
         setupFiles: './tests/setup.ts',
         exclude: ['**/node_modules/**', '**/e2e/**'],
+        coverage: {
+            provider: 'v8',
+            exclude: [
+                ...coverageConfigDefaults.exclude,
+                'src/data/collections/**/*.json',
+                'src/routeTree.gen.ts',
+            ],
+            thresholds: {
+                lines: 90,
+                statements: 90,
+                functions: 90,
+                branches: 80,
+            },
+        },
     },
     resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- enforce Vitest global coverage thresholds for executable code
- exclude static collection JSON and generated route tree output from coverage totals
- surface coverage threshold expectations in the PR quality gate summary and comment
- document both the coverage policy and the branch freshness check before commits/PRs

## Verification
- npx vitest run scripts/__tests__/build-lib.test.mjs scripts/github/__tests__/comment-ci-report.test.mjs
- npm run test:coverage
- npm test -- --run
- npm run lint
- npm run build
- npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary

No Playwright E2E run was needed because this changes CI/test reporting and docs only, not browser-facing behavior.

Closes #43