### PR TITLE
test: add coverage buffer for maintenance scripts

### DIFF
--- a/scripts/dictionary/__tests__/dictionary-lib.test.mjs
+++ b/scripts/dictionary/__tests__/dictionary-lib.test.mjs
@@ -34,15 +34,19 @@ describe('dictionary artifact tooling', () => {
         const envFile = path.join(outDir, '.env')
         const previousBucket = process.env.R2_DICTIONARY_BUCKET
         const previousAccount = process.env.R2_ACCOUNT_ID
+        const previousSecret = process.env.R2_SECRET_ACCESS_KEY
         try {
             process.env.R2_DICTIONARY_BUCKET = 'existing-bucket'
             delete process.env.R2_ACCOUNT_ID
-            await writeFile(envFile, 'R2_DICTIONARY_BUCKET=file-bucket\nR2_ACCOUNT_ID="abc123"\n')
+            delete process.env.R2_SECRET_ACCESS_KEY
+            await writeFile(envFile, 'R2_DICTIONARY_BUCKET=file-bucket\nR2_ACCOUNT_ID="abc123"\nR2_SECRET_ACCESS_KEY=\'quoted-secret\'\n')
 
             await expect(loadDotenv(envFile)).resolves.toBe(true)
+            await expect(loadDotenv(path.join(outDir, 'missing.env'))).resolves.toBe(false)
 
             expect(process.env.R2_DICTIONARY_BUCKET).toBe('existing-bucket')
             expect(process.env.R2_ACCOUNT_ID).toBe('abc123')
+            expect(process.env.R2_SECRET_ACCESS_KEY).toBe('quoted-secret')
         } finally {
             if (previousBucket === undefined) {
                 delete process.env.R2_DICTIONARY_BUCKET
@@ -53,6 +57,11 @@ describe('dictionary artifact tooling', () => {
                 delete process.env.R2_ACCOUNT_ID
             } else {
                 process.env.R2_ACCOUNT_ID = previousAccount
+            }
+            if (previousSecret === undefined) {
+                delete process.env.R2_SECRET_ACCESS_KEY
+            } else {
+                process.env.R2_SECRET_ACCESS_KEY = previousSecret
             }
             await rm(outDir, { recursive: true, force: true })
         }
@@ -198,6 +207,50 @@ describe('dictionary artifact tooling', () => {
         }
     })
 
+    it('validation reports missing search and entries directories', async () => {
+        const versionDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-missing-dirs-'))
+        try {
+            await writeFile(path.join(versionDir, 'manifest.json'), '{"searchIndexPath":"search-index.json"}\n')
+            await writeFile(path.join(versionDir, 'build-stats.json'), '{"sourceSha256":"abc"}\n')
+            await writeFile(path.join(versionDir, 'search-index.json'), '{}\n')
+
+            const validation = await validateDictionaryArtifacts({ versionDir })
+
+            expect(validation.ok).toBe(false)
+            expect(validation.problems).toEqual(expect.arrayContaining([
+                'Missing search directory',
+                'Missing entries directory',
+            ]))
+        } finally {
+            await rm(versionDir, { recursive: true, force: true })
+        }
+    })
+
+    it('validation catches malformed and invalid entry chunks', async () => {
+        const versionDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-bad-entries-'))
+        try {
+            await mkdir(path.join(versionDir, 'search'))
+            await mkdir(path.join(versionDir, 'entries'))
+            await writeFile(path.join(versionDir, 'manifest.json'), '{"searchIndexPath":"search-index.json"}\n')
+            await writeFile(path.join(versionDir, 'build-stats.json'), '{"sourceSha256":"abc"}\n')
+            await writeFile(path.join(versionDir, 'search-index.json'), '{"p6172":["ar.json"]}\n')
+            await writeFile(path.join(versionDir, 'search', 'ar.json'), '[{"normalized":"arb"}]\n')
+            await writeFile(path.join(versionDir, 'entries', 'malformed.json'), '{')
+            await writeFile(path.join(versionDir, 'entries', 'invalid.json'), '[]\n')
+
+            const validation = await validateDictionaryArtifacts({ versionDir })
+
+            expect(validation.ok).toBe(false)
+            expect(validation.problems).toEqual(expect.arrayContaining([
+                'entries/malformed.json is malformed JSON',
+                'entries/malformed.json must contain entries',
+                'entries/invalid.json must contain entries',
+            ]))
+        } finally {
+            await rm(versionDir, { recursive: true, force: true })
+        }
+    })
+
     it('validation requires a search index', async () => {
         const versionDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-missing-index-'))
         try {
@@ -260,6 +313,127 @@ describe('dictionary artifact tooling', () => {
         }
     })
 
+    it('refuses to upload over an existing manifest unless forced', async () => {
+        const outDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-existing-r2-'))
+        try {
+            const result = await buildDictionaryArtifacts({
+                source: fixture,
+                version: 'v2026-05-01',
+                outDir,
+                entryBucketCount: 8,
+            })
+            const calls = []
+            const fetcher = async (url, init) => {
+                calls.push({ url: String(url), init })
+                return r2Response({ ok: true, status: 200 })
+            }
+
+            await expect(uploadDictionaryArtifacts({
+                versionDir: result.versionDir,
+                bucket: 'dictionary-bucket',
+                accountId: 'abc123',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                fetcher,
+            })).rejects.toThrow('Refusing upload: dictionary/v2026-05-01/manifest.json already exists. Pass --force to overwrite.')
+
+            expect(calls).toHaveLength(1)
+            expect(calls[0].init.method).toBe('HEAD')
+        } finally {
+            await rm(outDir, { recursive: true, force: true })
+        }
+    })
+
+    it('uploads without checking the manifest when force is true', async () => {
+        const outDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-force-r2-'))
+        try {
+            const result = await buildDictionaryArtifacts({
+                source: fixture,
+                version: 'v2026-05-01',
+                outDir,
+                entryBucketCount: 8,
+            })
+            const calls = []
+            const fetcher = async (url, init) => {
+                calls.push({ url: String(url), init })
+                return r2Response({ ok: true, status: 200 })
+            }
+
+            const uploadLines = await uploadDictionaryArtifacts({
+                versionDir: result.versionDir,
+                bucket: 'dictionary-bucket',
+                accountId: 'abc123',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                fetcher,
+                force: true,
+                uploadConcurrency: 1,
+            })
+
+            expect(calls.every((call) => call.init.method === 'PUT')).toBe(true)
+            expect(uploadLines.some((line) => line.includes('/manifest.json'))).toBe(true)
+        } finally {
+            await rm(outDir, { recursive: true, force: true })
+        }
+    })
+
+    it('surfaces non-404 manifest existence check failures', async () => {
+        const outDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-head-fail-r2-'))
+        try {
+            const result = await buildDictionaryArtifacts({
+                source: fixture,
+                version: 'v2026-05-01',
+                outDir,
+                entryBucketCount: 8,
+            })
+            const fetcher = async () => ({
+                ...r2Response({ ok: false, status: 503, body: 'temporarily unavailable' }),
+            })
+
+            await expect(uploadDictionaryArtifacts({
+                versionDir: result.versionDir,
+                bucket: 'dictionary-bucket',
+                accountId: 'abc123',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                fetcher,
+            })).rejects.toThrow('R2 object existence check failed: 503 temporarily unavailable')
+        } finally {
+            await rm(outDir, { recursive: true, force: true })
+        }
+    })
+
+    it('surfaces failed upload object keys and statuses', async () => {
+        const outDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-put-fail-r2-'))
+        try {
+            const result = await buildDictionaryArtifacts({
+                source: fixture,
+                version: 'v2026-05-01',
+                outDir,
+                entryBucketCount: 8,
+            })
+            const fetcher = async (_url, init) => ({
+                ...r2Response({
+                    ok: false,
+                    status: init.method === 'HEAD' ? 404 : 403,
+                    body: init.method === 'HEAD' ? '' : 'denied',
+                }),
+            })
+
+            await expect(uploadDictionaryArtifacts({
+                versionDir: result.versionDir,
+                bucket: 'dictionary-bucket',
+                accountId: 'abc123',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                fetcher,
+                uploadConcurrency: 1,
+            })).rejects.toThrow(/R2 upload failed for dictionary\/v2026-05-01\/.+: 403 denied/)
+        } finally {
+            await rm(outDir, { recursive: true, force: true })
+        }
+    })
+
     it('uploads with signed R2 S3 API requests', async () => {
         const outDir = await mkdtemp(path.join(tmpdir(), 'langtype-dict-r2-'))
         try {
@@ -309,4 +483,12 @@ async function findSearchRow(versionDir, encodedPrefix, normalized) {
         if (row) return row
     }
     return null
+}
+
+function r2Response({ ok, status, body = '' }) {
+    return {
+        ok,
+        status,
+        text: async () => body,
+    }
 }

--- a/scripts/github/__tests__/comment-ci-report.test.mjs
+++ b/scripts/github/__tests__/comment-ci-report.test.mjs
@@ -59,4 +59,117 @@ describe('CI report comment', () => {
         expect(comment).toContain('| Branches | 81.00% | 80% |')
         expect(comment).toContain('failed job may be from tests or threshold enforcement')
     })
+
+    it('uses fallback summaries when reports are missing', async () => {
+        await rm('coverage', { recursive: true, force: true })
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('| Unit/component tests | pass | No JUnit report found. |')
+        expect(comment).toContain('| Coverage | fail | No coverage summary found.; failed job may be from tests or threshold enforcement; see artifacts for details |')
+        expect(comment).toContain('| End-to-end tests | pass | No Playwright JSON report found. |')
+    })
+
+    it('summarizes and lists Vitest JUnit failures and errors', async () => {
+        await mkdir('reports/vitest', { recursive: true })
+        await writeFile('reports/vitest/junit.xml', [
+            '<testsuites>',
+            '<testsuite tests="3" failures="1" errors="1" skipped="1">',
+            '<testcase name="fails" classname="alpha suite"><failure /></testcase>',
+            '<testcase name="errors" classname="beta suite"><error /></testcase>',
+            '<testcase classname="gamma suite" name="skips"><skipped /></testcase>',
+            '</testsuite>',
+            '</testsuites>',
+        ].join(''))
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('| Unit/component tests | pass | 3 tests, 2 failed, 1 skipped |')
+        expect(comment).toContain('<details><summary>Vitest failures</summary>')
+        expect(comment).toContain('- alpha suite - fails')
+        expect(comment).toContain('- beta suite - errors')
+    })
+
+    it('uses fallback messaging when coverage totals are missing', async () => {
+        await writeFile('coverage/coverage-summary.json', JSON.stringify({
+            'src/example.ts': {
+                lines: { pct: 91 },
+            },
+        }))
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('| Coverage | fail | Coverage summary did not include totals.; failed job may be from tests or threshold enforcement; see artifacts for details |')
+        expect(comment).not.toContain('### Coverage totals')
+    })
+
+    it('summarizes Playwright failures and skipped tests', async () => {
+        await mkdir('reports/playwright', { recursive: true })
+        await writeFile('reports/playwright/results.json', JSON.stringify({
+            suites: [{
+                title: 'chromium',
+                specs: [
+                    { title: 'loads app', tests: [{ outcome: 'expected' }] },
+                    { title: 'submits answer', tests: [{ outcome: 'unexpected' }] },
+                    { title: 'exports data', tests: [{ status: 'skipped' }] },
+                ],
+                suites: [{
+                    title: 'nested',
+                    specs: [{ title: 'times out', tests: [{ status: 'timedOut' }] }],
+                }],
+            }],
+        }))
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('| End-to-end tests | pass | 4 tests, 2 failed, 1 skipped |')
+        expect(comment).toContain('<details><summary>Playwright failures</summary>')
+        expect(comment).toContain('- chromium > submits answer')
+        expect(comment).toContain('- chromium > nested > times out')
+    })
+
+    it('escapes markdown table cells', async () => {
+        await writeFile('coverage/coverage-summary.json', JSON.stringify({
+            total: {
+                lines: { pct: 91 },
+                statements: { pct: 92 },
+                functions: { pct: 93 },
+                branches: { pct: 81 },
+            },
+            [`${process.cwd()}/src/file|with\nnewline.ts`]: {
+                lines: { pct: 91 },
+                statements: { pct: 92 },
+                functions: { pct: 93 },
+                branches: { pct: 81 },
+            },
+        }))
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('src/file\\|with<br>newline.ts')
+    })
+
+    it('renders all check outcomes', () => {
+        process.env.LINT_OUTCOME = 'success'
+        process.env.UNIT_OUTCOME = 'failure'
+        process.env.COVERAGE_OUTCOME = 'cancelled'
+        process.env.BUILD_OUTCOME = 'skipped'
+        delete process.env.E2E_OUTCOME
+
+        const comment = buildComment(context())
+
+        expect(comment).toContain('| Lint | pass | `npm run lint` |')
+        expect(comment).toContain('| Unit/component tests | fail | No JUnit report found. |')
+        expect(comment).toContain('| Coverage | cancelled | see coverage tables below |')
+        expect(comment).toContain('| Production build | skipped | `npm run build` |')
+        expect(comment).toContain('| End-to-end tests | not run | No Playwright JSON report found. |')
+    })
 })
+
+function context() {
+    return {
+        serverUrl: 'https://github.com',
+        repository: 'owner/repo',
+        runId: '123',
+    }
+}


### PR DESCRIPTION
## Summary
- add focused CI report comment tests for missing reports, failures, escaping, and check outcomes
- add focused dictionary tooling tests for validation gaps and R2 upload failure handling
- keep existing coverage thresholds unchanged

## Verification
- npx vitest run scripts/github/__tests__/comment-ci-report.test.mjs scripts/dictionary/__tests__/dictionary-lib.test.mjs
- npm run test:coverage
- npm run lint

Closes #46