### PR TITLE
test: cover normal wrong-answer retry

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -389,6 +389,10 @@ Maintenance:
 Key gotchas:
 - `reuseExistingServer: !process.env.CI` — kill the dev server before running tests after code changes, or Playwright reuses the stale one.
 - `@playwright/test` is the test runner; `playwright` is the browser library — they are separate packages.
+- For normal-mode practice retry/reinsertion tests, prefer `?mode=normal` over a `questionId` deep link. `useUrlSync` treats `questionId` as authoritative and can pull the game back to the deep-linked card after auto-advance.
+- For deterministic practice order, mock `Math.random` in `page.addInitScript` and account for all random calls consumed by initial shuffling before retry reinsertion.
+- The Netzwerk plural collections provide stable two-gap practice fixtures and match the existing E2E browser input path.
+- Validate carefully before using Playwright fake clocks in practice-flow E2E tests; timer control can change input/submission behavior.
 
 E2E audit checklist:
 

--- a/e2e/wrong-answer-retry.spec.ts
+++ b/e2e/wrong-answer-retry.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const NORMAL_RETRY_URL = '/collections/netzwerk_neu_a1_k1_nomen_plural?mode=normal'
+
+test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+        localStorage.setItem('lt_theme', 'warm')
+
+        let calls = 0
+        Math.random = () => {
+            calls += 1
+            return calls <= 25 ? 0.999999 : 0
+        }
+    })
+})
+
+async function answerCurrentCard(page: Page, article: string, plural: string) {
+    const articleGap = page.getByRole('textbox', { name: 'Translation gap 1' })
+    const pluralGap = page.getByRole('textbox', { name: 'Translation gap 2' })
+
+    await articleGap.fill(article)
+    await articleGap.press('Enter')
+    await pluralGap.fill(plural)
+    await pluralGap.press('Enter')
+}
+
+test('wrong answer in normal mode keeps the session alive and retries the card', async ({ page }) => {
+    await page.goto(NORMAL_RETRY_URL)
+
+    await expect(page.getByText('First Name', { exact: true })).toBeVisible()
+
+    await answerCurrentCard(page, 'wrong', 'wrong')
+
+    await expect(page.getByText(/incorrect/i)).toBeVisible()
+    await expect(page.getByText('Correct: der Vorname, die Vornamen')).toBeVisible()
+
+    await expect(page.getByText('Last Name', { exact: true })).toBeVisible({ timeout: 7000 })
+    await expect(page.getByRole('heading', { name: /Netzwerk Neu A1.*Kapitel 1: Artikel \+ Plural/ })).toBeVisible()
+
+    await answerCurrentCard(page, 'der', 'Nachnamen')
+    await expect(page.getByText(/correct/i)).toBeVisible()
+
+    await expect(page.getByText('First Name', { exact: true })).toBeVisible({ timeout: 7000 })
+
+    await answerCurrentCard(page, 'der', 'Vornamen')
+
+    await expect(page.getByText(/correct/i)).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- Add Playwright coverage for normal practice retry after an incorrect answer
- Verify incorrect feedback, continued session progress, and successful answer of the reinserted card
- Document E2E gotchas for normal-mode retry tests and deterministic practice ordering

## Verification
- npx playwright test e2e/wrong-answer-retry.spec.ts
- npm run lint

Closes #21