### PR TITLE
chore: patch Vite security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "playwright": "^1.58.0",
         "tailwindcss": "^4.1.18",
         "typescript": "^5",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.0.18",
         "wrangler": "^4.60.0"
@@ -8077,9 +8077,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "playwright": "^1.58.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^5",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.18",
     "wrangler": "^4.60.0"


### PR DESCRIPTION
## Summary
- update the direct Vite dependency from 7.3.1 to 7.3.2
- refresh package-lock.json so Vite resolves to the patched 7.3.2 tarball
- confirm Vite plugins and consumers dedupe to Vite 7.3.2

## Verification
- npm ls vite
- npm run lint
- npm test
- npm run build

Closes #49