### PR TITLE
chore: patch eslint dev dependency alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5699,9 +5699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6694,9 +6694,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "picomatch": "^4.0.4",
     "rollup": "^4.59.0",
     "undici": "^7.24.0",
-    "readdirp": "^5.0.0"
+    "readdirp": "^5.0.0",
+    "flatted@^3.2.9": "^3.4.2",
+    "minimatch@^3.1.2": "^3.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- add narrow npm overrides for ESLint's vulnerable flatted and minimatch dependency ranges
- refresh the lockfile so flatted resolves to 3.4.2 and minimatch 3.x resolves to 3.1.5
- preserve existing minimatch 10 consumers in the TypeScript ESLint and SonarJS trees

## Verification
- npm ls flatted minimatch
- npm run lint
- npm test
- npm audit --audit-level=high

## Notes
- Full npm audit still reports unrelated moderate advisories for ajv, brace-expansion, postcss, and srvx; those are outside issue #52.

Closes #52