### PR TITLE
fix: clean up route export warnings

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -129,8 +129,9 @@ const recordReview = useSRSStore((s) => s.recordReview)
 ## Route Files
 
 ```typescript
+// src/routes/collections.$id.tsx
 export const Route = createFileRoute('/collections/$id')({
-    component: CollectionPage,
+    component: CollectionRoute,
     loader: async ({ params }) => {
         const collection = await getCollection(params.id)
         if (!collection) throw notFound()
@@ -139,17 +140,32 @@ export const Route = createFileRoute('/collections/$id')({
     validateSearch: (search: Record<string, unknown>) => { ... },
 })
 
-export function CollectionPage() {
+function CollectionRoute() {
     const collection = Route.useLoaderData()
     const { mode, view } = Route.useSearch()
     const navigate = useNavigate({ from: Route.fullPath })
+
+    return (
+        <CollectionPage
+            collection={collection}
+            mode={mode}
+            view={view}
+            onBack={() => navigate({ search: () => ({}) })}
+        />
+    )
+}
+
+// src/components/features/CollectionPage.tsx
+export function CollectionPage({ collection, mode, view, onBack }: Props) {
 ```
 
 - Loader throws `notFound()` for missing resources — never returns `null`
 - `validateSearch` type-guards all URL params; default to `undefined` for missing ones
-- Component is a named export so tests can render it directly
-- Use `Route.useLoaderData()` and `Route.useSearch()`, not the generic hooks
-- Keep route files thin: routing setup, loaders, search param validation, and page-level composition only. Move non-trivial client state into hooks, typed UI into `components/domain` or `components/features`, and pure transforms into `src/lib`.
+- Route files export only `Route`; do not export page components, helpers, or types from `src/routes/*`
+- Route components may be unexported thin adapters that call `Route.useLoaderData()` / `Route.useSearch()` and pass typed props to page components
+- Testable page components live outside `src/routes`, usually in `components/features`; tests render those exported components directly
+- Test route wiring separately when needed by importing `Route` and asserting loader/search/params behavior through `Route.options`
+- Keep route files thin: routing setup, loaders, params/search validation, and adapter composition only. Move client state into hooks, typed UI into `components/domain` or `components/features`, and pure transforms into `src/lib`.
 
 ## Naming
 

--- a/e2e/custom-collection-delete.spec.ts
+++ b/e2e/custom-collection-delete.spec.ts
@@ -22,6 +22,7 @@ test('deleting a custom collection removes it from home and practice access', as
     await expect(page.getByText('1 challenge ready')).toBeVisible()
 
     await page.getByRole('link', { name: 'Home' }).click()
+    await page.reload()
     await page.getByRole('button', { name: 'Custom' }).click()
     await expect(page.getByRole('link', { name: `${title} Custom` })).toBeVisible()
 

--- a/src/components/features/CollectionGamePage.tsx
+++ b/src/components/features/CollectionGamePage.tsx
@@ -1,0 +1,216 @@
+import { Link } from '@tanstack/react-router'
+import { useEffect, useMemo } from 'react'
+import { ModePicker } from '@/components/features/ModePicker'
+import { SRSAllDoneScreen } from '@/components/features/SRSAllDoneScreen'
+import { SRSProgressView } from '@/components/features/SRSProgressView'
+import { SRSQueuePanel } from '@/components/features/SRSQueuePanel'
+import { TypingGame } from '@/components/features/TypingGame'
+import { Button } from '@/components/ui/Button'
+import { useSessionChallenges } from '@/hooks/useSessionChallenges'
+import {
+    isValidCustomCollection,
+    toPlayableCollection,
+    useCustomCollectionsStore,
+} from '@/store/useCustomCollectionsStore'
+import { useSRSStore } from '@/store/useSRSStore'
+import type { Challenge, Collection } from '@/types/challenge'
+
+const EMPTY_CHALLENGES: Challenge[] = []
+
+export type CollectionLoaderData =
+    | { kind: 'bundled'; collection: Collection }
+    | { kind: 'custom'; id: string }
+
+export interface CollectionSearchState {
+    questionId?: string | number
+    mode?: 'normal' | 'srs'
+    view?: 'progress'
+}
+
+interface Props {
+    loaderData: CollectionLoaderData
+    search: CollectionSearchState
+    onGoToPicker: () => void
+    onStartNormal: () => void
+    onStartSRS: () => void
+    onGoToProgress: () => void
+    onQuestionChange: (newId: string) => void
+}
+
+const BackArrow = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-6 w-6"
+    >
+        <path d="m15 18-6-6 6-6" />
+    </svg>
+)
+
+export function CollectionGamePage({
+    loaderData,
+    search,
+    onGoToPicker,
+    onStartNormal,
+    onStartSRS,
+    onGoToProgress,
+    onQuestionChange,
+}: Props) {
+    const { questionId, mode, view } = search
+    const cards = useSRSStore((s) => s.cards)
+    const recordPlay = useSRSStore((s) => s.recordPlay)
+    const customCollection = useCustomCollectionsStore((s) => (
+        loaderData.kind === 'custom' ? s.collections[loaderData.id] : undefined
+    ))
+    const customHasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
+
+    const collection = useMemo(() => {
+        if (loaderData.kind === 'bundled') {
+            return loaderData.collection
+        }
+
+        if (!customCollection || !isValidCustomCollection(customCollection)) {
+            return undefined
+        }
+
+        return toPlayableCollection(customCollection)
+    }, [customCollection, loaderData])
+    const collectionId = collection?.id
+
+    const allChallenges = collection?.challenges ?? EMPTY_CHALLENGES
+    const challenges = useSessionChallenges({
+        collectionId: collectionId ?? '',
+        mode,
+        allChallenges,
+        cards,
+    })
+
+    useEffect(() => {
+        if (collectionId && (mode === 'srs' || mode === 'normal')) {
+            recordPlay(collectionId)
+        }
+    }, [mode, collectionId, recordPlay])
+
+    if (loaderData.kind === 'custom' && !customHasHydrated) {
+        return (
+            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
+                Loading collection...
+            </main>
+        )
+    }
+
+    if (!collection) {
+        return (
+            <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-4 text-center">
+                <h1 className="text-2xl font-bold">Collection not found</h1>
+                <p className="max-w-sm text-sm text-muted-foreground">
+                    This custom collection is not saved or is not playable on this device.
+                </p>
+                <Link
+                    to="/"
+                    className="rounded-[var(--radius)] border border-border px-3 py-2 text-sm font-medium transition-colors hover:border-primary"
+                >
+                    Home
+                </Link>
+            </main>
+        )
+    }
+
+    if (view === 'progress') {
+        return (
+            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
+                <Button
+                    variant="link"
+                    onClick={onGoToPicker}
+                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
+                    title="Back"
+                >
+                    <BackArrow />
+                    <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
+                </Button>
+                <SRSProgressView collection={collection} onBack={onGoToPicker} />
+            </main>
+        )
+    }
+
+    if (mode === undefined) {
+        return (
+            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
+                <Link
+                    to="/"
+                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+                    title="Back to Home"
+                >
+                    <BackArrow />
+                    <span className="sr-only md:not-sr-only text-sm font-medium">Home</span>
+                </Link>
+                <ModePicker
+                    collection={collection}
+                    onSelectNormal={onStartNormal}
+                    onSelectSRS={onStartSRS}
+                    onViewProgress={onGoToProgress}
+                />
+            </main>
+        )
+    }
+
+    if (mode === 'srs' && challenges.length === 0) {
+        return (
+            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
+                <Button
+                    variant="link"
+                    onClick={onGoToPicker}
+                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
+                    title="Back"
+                >
+                    <BackArrow />
+                    <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
+                </Button>
+                <SRSAllDoneScreen
+                    collectionId={collection.id}
+                    challenges={collection.challenges ?? []}
+                    onBack={onGoToPicker}
+                />
+            </main>
+        )
+    }
+
+    return (
+        <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
+            <Button
+                variant="link"
+                onClick={onGoToPicker}
+                className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
+                title="Back"
+            >
+                <BackArrow />
+                <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
+            </Button>
+            <div className="mb-4 text-center">
+                <h2 className="text-xl text-muted-foreground">{collection.title}</h2>
+            </div>
+            <TypingGame
+                key={mode}
+                challenges={challenges}
+                freeInput={collection.freeInput}
+                initialQuestionId={questionId ? String(questionId) : undefined}
+                onQuestionChange={onQuestionChange}
+                onFinished={mode === 'srs' ? onGoToPicker : undefined}
+                srsContext={mode === 'srs' ? { collectionId: collection.id } : undefined}
+            />
+            {mode === 'srs' && (
+                <SRSQueuePanel
+                    collectionId={collection.id}
+                    allChallenges={collection.challenges ?? []}
+                />
+            )}
+        </main>
+    )
+}

--- a/src/components/features/DictionaryPage.tsx
+++ b/src/components/features/DictionaryPage.tsx
@@ -1,0 +1,5 @@
+import { DictionaryBrowser } from '@/components/features/DictionaryBrowser'
+
+export function DictionaryPage() {
+    return <DictionaryBrowser />
+}

--- a/src/components/features/EditCustomCollectionPage.tsx
+++ b/src/components/features/EditCustomCollectionPage.tsx
@@ -1,0 +1,37 @@
+import { Link } from '@tanstack/react-router'
+import { CollectionEditor } from '@/components/features/CollectionEditor'
+import { useCustomCollectionsStore } from '@/store/useCustomCollectionsStore'
+
+interface Props {
+    id: string
+}
+
+export function EditCustomCollectionPage({ id }: Props) {
+    const collection = useCustomCollectionsStore((s) => s.collections[id])
+    const hasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
+
+    if (!hasHydrated) {
+        return (
+            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
+                Loading collection...
+            </main>
+        )
+    }
+
+    if (!collection) {
+        return (
+            <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-4 text-center">
+                <h1 className="text-2xl font-bold">Collection not found</h1>
+                <p className="text-sm text-muted-foreground">This custom collection is not saved on this device.</p>
+                <Link
+                    to="/"
+                    className="rounded-[var(--radius)] border border-border px-3 py-2 text-sm font-medium transition-colors hover:border-primary"
+                >
+                    Home
+                </Link>
+            </main>
+        )
+    }
+
+    return <CollectionEditor collection={collection} />
+}

--- a/src/components/features/HomePage.tsx
+++ b/src/components/features/HomePage.tsx
@@ -1,0 +1,50 @@
+import { Link } from '@tanstack/react-router'
+import { CollectionFilters } from '@/components/features/home/CollectionFilters'
+import { CollectionList } from '@/components/features/home/CollectionList'
+import { SRSQueuePanel } from '@/components/features/SRSQueuePanel'
+import { IconPlus } from '@/components/ui/icons'
+import { useHomeCollections } from '@/hooks/useHomeCollections'
+import type { Collection } from '@/types/challenge'
+
+interface Props {
+    collections: Collection[]
+}
+
+export function HomePage({ collections }: Props) {
+    const homeCollections = useHomeCollections(collections)
+
+    return (
+        <main className="flex min-h-screen flex-col items-center justify-center p-4 md:p-24 bg-background">
+            <div className="w-full max-w-4xl">
+                <header className="mb-6">
+                    <p className="mono-label mb-1">collections</p>
+                    <Link
+                        to="/custom-collections/new"
+                        className="mt-3 inline-flex items-center gap-2 rounded-[var(--radius)] border border-border bg-card px-3 py-2 text-sm font-medium transition-colors hover:border-primary hover:bg-[var(--bg2)]"
+                    >
+                        <IconPlus className="h-4 w-4" />
+                        Create collection
+                    </Link>
+
+                    <CollectionFilters
+                        query={homeCollections.query}
+                        onQueryChange={homeCollections.setQuery}
+                        filter={homeCollections.filter}
+                        onFilterChange={homeCollections.setFilter}
+                        totalDue={homeCollections.totalDue}
+                        tags={homeCollections.allTags}
+                        activeTag={homeCollections.activeTag}
+                        onTagClick={homeCollections.handleTagClick}
+                    />
+                </header>
+
+                <CollectionList
+                    isHydrated={homeCollections.isHydrated}
+                    skeletonCollections={homeCollections.skeletonCollections}
+                    collections={homeCollections.visibleCollections}
+                />
+            </div>
+            <SRSQueuePanel />
+        </main>
+    )
+}

--- a/src/components/features/NewCustomCollectionPage.tsx
+++ b/src/components/features/NewCustomCollectionPage.tsx
@@ -1,0 +1,24 @@
+import { Navigate } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { CustomCollection, useCustomCollectionsStore } from '@/store/useCustomCollectionsStore'
+
+export function NewCustomCollectionPage() {
+    const createDraft = useCustomCollectionsStore((s) => s.createDraft)
+    const hasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
+    const [draft, setDraft] = useState<CustomCollection | null>(null)
+
+    useEffect(() => {
+        if (!hasHydrated || draft) return
+        setDraft(createDraft())
+    }, [createDraft, draft, hasHydrated])
+
+    if (!draft) {
+        return (
+            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
+                {hasHydrated ? 'Creating draft...' : 'Loading collections...'}
+            </main>
+        )
+    }
+
+    return <Navigate to="/custom-collections/$id/edit" params={{ id: draft.id }} replace />
+}

--- a/src/routes/__tests__/collections.$id.test.tsx
+++ b/src/routes/__tests__/collections.$id.test.tsx
@@ -5,8 +5,13 @@ import type { Collection } from '@/types/challenge'
 import type { SRSCard } from '@/types/srs'
 import type { MockInstance } from 'vitest'
 import type { CustomCollection } from '@/store/useCustomCollectionsStore'
+import type { CollectionSearchState } from '@/components/features/CollectionGamePage'
 
 const mockNavigate = vi.fn()
+const mockStartNormal = vi.fn()
+const mockStartSRS = vi.fn()
+const mockGoToProgress = vi.fn()
+const mockQuestionChange = vi.fn()
 let randomSpy: MockInstance
 const mockSRSState = vi.hoisted(() => ({
     cards: {} as Record<string, SRSCard>,
@@ -24,17 +29,11 @@ const mockCustomCollectionsState = vi.hoisted(() => ({
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@tanstack/react-router')>()
-    const mockUseLoaderData = vi.fn()
     return {
         ...actual,
         Link: ({ children, to, className }: { children: ReactNode; to: string; className?: string }) => (
             <a href={to} className={className}>{children}</a>
         ),
-        createFileRoute: () => () => ({
-            useLoaderData: mockUseLoaderData,
-            useSearch: vi.fn(() => ({ questionId: undefined, mode: 'normal' })),
-        }),
-        _mockUseLoaderData: mockUseLoaderData,
         useNavigate: () => mockNavigate,
     }
 })
@@ -53,7 +52,7 @@ vi.mock('@/store/useCustomCollectionsStore', async (importOriginal) => {
     }
 })
 
-import { CollectionGamePage, Route } from '../collections.$id'
+import { CollectionGamePage } from '@/components/features/CollectionGamePage'
 
 const mockCollection: Collection = {
     id: 'test',
@@ -74,6 +73,26 @@ const customLoaderData = (id: string) => ({
     kind: 'custom' as const,
     id,
 })
+
+function renderPage({
+    loaderData = bundledLoaderData(mockCollection),
+    search = { questionId: undefined, mode: 'normal' as const },
+}: {
+    loaderData?: ReturnType<typeof bundledLoaderData> | ReturnType<typeof customLoaderData>
+    search?: CollectionSearchState
+} = {}) {
+    return render(
+        <CollectionGamePage
+            loaderData={loaderData}
+            search={search}
+            onGoToPicker={mockNavigate}
+            onStartNormal={mockStartNormal}
+            onStartSRS={mockStartSRS}
+            onGoToProgress={mockGoToProgress}
+            onQuestionChange={mockQuestionChange}
+        />
+    )
+}
 
 function reviewedCard(collectionId: string, challengeId: string): SRSCard {
     return {
@@ -96,8 +115,6 @@ describe('CollectionGamePage', () => {
         mockSRSState._hasHydrated = true
         mockCustomCollectionsState.collections = {}
         mockCustomCollectionsState._hasHydrated = true
-        vi.mocked(Route.useLoaderData).mockReturnValue(bundledLoaderData(mockCollection))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'normal' })
     })
 
     afterEach(() => {
@@ -106,9 +123,7 @@ describe('CollectionGamePage', () => {
     })
 
     it('renders the mode picker when no mode is selected', () => {
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: undefined })
-
-        render(<CollectionGamePage />)
+        renderPage({ search: { questionId: undefined, mode: undefined } })
 
         expect(screen.getByRole('heading', { name: 'Test' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /practice all/i })).toBeInTheDocument()
@@ -116,7 +131,7 @@ describe('CollectionGamePage', () => {
     })
 
     it('renders the game when mode=normal', () => {
-        render(<CollectionGamePage />)
+        renderPage()
 
         expect(screen.getByText('Hello')).toBeInTheDocument()
         expect(screen.getByRole('textbox', { name: 'Translation answer' })).toBeInTheDocument()
@@ -124,13 +139,12 @@ describe('CollectionGamePage', () => {
     })
 
     it('renders the SRS all-done screen when mode=srs and no cards are due', () => {
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'srs' })
         mockSRSState.cards = {
             'test:1': reviewedCard('test', '1'),
             'test:2': reviewedCard('test', '2'),
         }
 
-        render(<CollectionGamePage />)
+        renderPage({ search: { questionId: undefined, mode: 'srs' } })
 
         expect(screen.getByRole('heading', { name: 'All caught up!' })).toBeInTheDocument()
         expect(screen.getByText(/Next cards due in/i)).toBeInTheDocument()
@@ -138,9 +152,7 @@ describe('CollectionGamePage', () => {
     })
 
     it('renders the game when mode=srs and cards are due', () => {
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'srs' })
-
-        render(<CollectionGamePage />)
+        renderPage({ search: { questionId: undefined, mode: 'srs' } })
 
         expect(screen.getByText('Hello')).toBeInTheDocument()
         expect(screen.getByText('1 card remaining')).toBeInTheDocument()
@@ -148,7 +160,7 @@ describe('CollectionGamePage', () => {
     })
 
     it('navigates when the real game advances to the next question', () => {
-        render(<CollectionGamePage />)
+        renderPage()
 
         const input = screen.getByRole('textbox', { name: 'Translation answer' })
         fireEvent.change(input, { target: { value: 'Hallo' } })
@@ -158,23 +170,17 @@ describe('CollectionGamePage', () => {
             vi.advanceTimersByTime(5100)
         })
 
-        expect(mockNavigate).toHaveBeenCalledWith(
-            expect.objectContaining({ replace: true })
-        )
-
-        const callArg = mockNavigate.mock.calls.at(-1)?.[0]
-        const updatedSearch = callArg.search({ mode: 'normal' })
-        expect(updatedSearch).toMatchObject({ questionId: 2, mode: 'normal' })
+        expect(mockQuestionChange).toHaveBeenCalledWith('2')
     })
 
     it('navigates to picker when the real SRS game finishes', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(bundledLoaderData({
-            ...mockCollection,
-            challenges: [{ id: '1', original: 'Hello', translation: 'Hallo' }],
-        }))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'srs' })
-
-        render(<CollectionGamePage />)
+        renderPage({
+            loaderData: bundledLoaderData({
+                ...mockCollection,
+                challenges: [{ id: '1', original: 'Hello', translation: 'Hallo' }],
+            }),
+            search: { questionId: undefined, mode: 'srs' },
+        })
 
         const input = screen.getByRole('textbox', { name: 'Translation answer' })
         fireEvent.change(input, { target: { value: 'Hallo' } })
@@ -185,17 +191,11 @@ describe('CollectionGamePage', () => {
             vi.advanceTimersByTime(2100)
         })
 
-        expect(mockNavigate).toHaveBeenCalledWith(
-            expect.objectContaining({ search: expect.any(Function) })
-        )
-        const callArg = mockNavigate.mock.calls.at(-1)?.[0]
-        expect(callArg.search({})).toEqual({})
+        expect(mockNavigate).toHaveBeenCalled()
     })
 
     it('passes initialQuestionId from URL to TypingGame', () => {
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: '2', mode: 'srs' })
-
-        render(<CollectionGamePage />)
+        renderPage({ search: { questionId: '2', mode: 'srs' } })
 
         expect(screen.getByText('World')).toBeInTheDocument()
         expect(screen.queryByText('Hello')).not.toBeInTheDocument()
@@ -219,13 +219,13 @@ describe('CollectionGamePage', () => {
                 { id: 'ch_mooolutc_843ims', original: 'The child plays with its toy.', translation: '(Das Kind spielt mit )seinem( Spielzeug.)' },
             ],
         }
-        vi.mocked(Route.useLoaderData).mockReturnValue(bundledLoaderData(importedCollection))
-        vi.mocked(Route.useSearch).mockReturnValue({
-            questionId: 'ch_mooolutc_843imj',
-            mode: 'srs',
+        renderPage({
+            loaderData: bundledLoaderData(importedCollection),
+            search: {
+                questionId: 'ch_mooolutc_843imj',
+                mode: 'srs',
+            },
         })
-
-        render(<CollectionGamePage />)
 
         expect(screen.getByText('This is my dog.')).toBeInTheDocument()
         expect(screen.getByText('Das ist')).toBeInTheDocument()
@@ -234,19 +234,18 @@ describe('CollectionGamePage', () => {
     })
 
     it('shows a loading state for custom routes while custom collection storage hydrates', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(customLoaderData('custom_ready'))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: undefined })
         mockCustomCollectionsState._hasHydrated = false
 
-        render(<CollectionGamePage />)
+        renderPage({
+            loaderData: customLoaderData('custom_ready'),
+            search: { questionId: undefined, mode: undefined },
+        })
 
         expect(screen.getByText('Loading collection...')).toBeInTheDocument()
         expect(screen.queryByRole('heading', { name: 'Collection not found' })).not.toBeInTheDocument()
     })
 
     it('renders the mode picker for a hydrated valid custom collection route', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(customLoaderData('custom_ready'))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: undefined })
         mockCustomCollectionsState.collections = {
             custom_ready: {
                 id: 'custom_ready',
@@ -262,7 +261,10 @@ describe('CollectionGamePage', () => {
             },
         }
 
-        render(<CollectionGamePage />)
+        renderPage({
+            loaderData: customLoaderData('custom_ready'),
+            search: { questionId: undefined, mode: undefined },
+        })
 
         expect(screen.getByRole('heading', { name: 'Ready custom' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /practice all/i })).toBeInTheDocument()
@@ -270,10 +272,10 @@ describe('CollectionGamePage', () => {
     })
 
     it('renders a route-local not-found state for a missing hydrated custom collection route', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(customLoaderData('custom_missing'))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: undefined })
-
-        render(<CollectionGamePage />)
+        renderPage({
+            loaderData: customLoaderData('custom_missing'),
+            search: { questionId: undefined, mode: undefined },
+        })
 
         expect(screen.getByRole('heading', { name: 'Collection not found' })).toBeInTheDocument()
         expect(screen.getByText('This custom collection is not saved or is not playable on this device.')).toBeInTheDocument()
@@ -281,24 +283,25 @@ describe('CollectionGamePage', () => {
     })
 
     it('passes no initialQuestionId when questionId is absent', () => {
-        render(<CollectionGamePage />)
+        renderPage()
 
         expect(screen.getByText('Hello')).toBeInTheDocument()
     })
 
     it('snapshots due SRS challenges when the session starts', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(bundledLoaderData({
-            ...mockCollection,
-            challenges: [
-                { id: '1', translation: 'one' },
-                { id: '2', translation: 'two' },
-                { id: '3', translation: 'three' },
-            ],
-        }))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'srs' })
         mockSRSState.cards = { 'test:2': reviewedCard('test', '2') }
 
-        render(<CollectionGamePage />)
+        renderPage({
+            loaderData: bundledLoaderData({
+                ...mockCollection,
+                challenges: [
+                    { id: '1', translation: 'one' },
+                    { id: '2', translation: 'two' },
+                    { id: '3', translation: 'three' },
+                ],
+            }),
+            search: { questionId: undefined, mode: 'srs' },
+        })
 
         expect(screen.getByText(/Hello|Test/)).toBeInTheDocument()
         expect(screen.queryByText('World')).not.toBeInTheDocument()
@@ -306,31 +309,39 @@ describe('CollectionGamePage', () => {
     })
 
     it('keeps the active SRS challenge snapshot when cards change mid-session', () => {
-        vi.mocked(Route.useLoaderData).mockReturnValue(bundledLoaderData({
-            ...mockCollection,
-            challenges: [
-                { id: '1', translation: 'one' },
-                { id: '2', translation: 'two' },
-                { id: '3', translation: 'three' },
-            ],
-        }))
-        vi.mocked(Route.useSearch).mockReturnValue({ questionId: undefined, mode: 'srs' })
-
-        const { rerender } = render(<CollectionGamePage />)
+        const page = (
+            <CollectionGamePage
+                loaderData={bundledLoaderData({
+                    ...mockCollection,
+                    challenges: [
+                        { id: '1', translation: 'one' },
+                        { id: '2', translation: 'two' },
+                        { id: '3', translation: 'three' },
+                    ],
+                })}
+                search={{ questionId: undefined, mode: 'srs' }}
+                onGoToPicker={mockNavigate}
+                onStartNormal={mockStartNormal}
+                onStartSRS={mockStartSRS}
+                onGoToProgress={mockGoToProgress}
+                onQuestionChange={mockQuestionChange}
+            />
+        )
+        const { rerender } = render(page)
 
         mockSRSState.cards = {
             'test:1': reviewedCard('test', '1'),
             'test:2': reviewedCard('test', '2'),
             'test:3': reviewedCard('test', '3'),
         }
-        rerender(<CollectionGamePage />)
+        rerender(page)
 
         expect(screen.getByText('2 cards remaining')).toBeInTheDocument()
         expect(screen.queryByRole('heading', { name: 'All caught up!' })).not.toBeInTheDocument()
     })
 
     it('records collection play when a session mode is active', () => {
-        render(<CollectionGamePage />)
+        renderPage()
 
         expect(mockSRSState.recordPlay).toHaveBeenCalledWith('test')
     })

--- a/src/routes/__tests__/dictionary.test.tsx
+++ b/src/routes/__tests__/dictionary.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/services/dictionaryService', () => ({
     getDictionaryEntry: mockGetDictionaryEntry,
 }))
 
-import { DictionaryPage } from '../dictionary'
+import { DictionaryPage } from '@/components/features/DictionaryPage'
 
 const searchItem: DictionarySearchItem = {
     id: 'arbeiten-id',

--- a/src/routes/__tests__/index.test.tsx
+++ b/src/routes/__tests__/index.test.tsx
@@ -18,8 +18,6 @@ vi.mock('idb-keyval', () => ({
     del: idb.del,
 }))
 
-const mockUseLoaderData = vi.hoisted(() => vi.fn())
-
 interface MockLinkProps {
     children: ReactNode
     className?: string
@@ -46,13 +44,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
                 </a>
             )
         },
-        createFileRoute: () => () => ({ useLoaderData: mockUseLoaderData }),
     }
 })
 
 import { useCustomCollectionsStore } from '@/store/useCustomCollectionsStore'
 import { useSRSStore } from '@/store/useSRSStore'
-import { Home } from '../index'
+import { HomePage } from '@/components/features/HomePage'
 
 // --- Helpers ---
 
@@ -91,11 +88,10 @@ describe('Home — tag filtering', () => {
             collections: {},
             _hasHydrated: true,
         })
-        mockUseLoaderData.mockReturnValue({ collections })
     })
 
     it('renders the custom collection creation entry point', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         expect(screen.getByRole('link', { name: 'Create collection' })).toHaveAttribute(
             'href',
             '/custom-collections/new',
@@ -117,7 +113,7 @@ describe('Home — tag filtering', () => {
             },
         })
 
-        render(<Home />)
+        render(<HomePage collections={collections} />)
 
         expect(screen.getByText('My German Set')).toBeInTheDocument()
         expect(screen.getAllByText('Custom').length).toBeGreaterThan(0)
@@ -140,19 +136,18 @@ describe('Home — tag filtering', () => {
             },
         })
 
-        render(<Home />)
+        render(<HomePage collections={collections} />)
 
         expect(screen.queryByText('Incomplete set')).not.toBeInTheDocument()
     })
 
     it('does not render tag pills when no collections have tags', () => {
-        mockUseLoaderData.mockReturnValue({ collections: [col('a', 'Alpha'), col('b', 'Beta')] })
-        render(<Home />)
+        render(<HomePage collections={[col('a', 'Alpha'), col('b', 'Beta')]} />)
         expect(screen.queryByRole('button', { name: 'X' })).not.toBeInTheDocument()
     })
 
     it('renders unique tag pills in encounter order', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         // Alpha introduces X then Y; Beta re-introduces X (deduped)
         const xBtn = screen.getByRole('button', { name: 'X' })
         const yBtn = screen.getByRole('button', { name: 'Y' })
@@ -163,7 +158,7 @@ describe('Home — tag filtering', () => {
     })
 
     it('filters collections to those with the selected tag', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         fireEvent.click(screen.getByRole('button', { name: 'Y' }))
         expect(screen.getByText('Alpha')).toBeInTheDocument()        // has Y
         expect(screen.queryByText('Beta')).not.toBeInTheDocument()   // only has X
@@ -171,13 +166,13 @@ describe('Home — tag filtering', () => {
     })
 
     it('hides untagged collections when a tag is active', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         fireEvent.click(screen.getByRole('button', { name: 'X' }))
         expect(screen.queryByText('Gamma')).not.toBeInTheDocument()
     })
 
     it('shows all collections after clicking the active tag again', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         fireEvent.click(screen.getByRole('button', { name: 'X' }))
         fireEvent.click(screen.getByRole('button', { name: 'X' })) // deselect
         expect(screen.getByText('Alpha')).toBeInTheDocument()
@@ -186,7 +181,7 @@ describe('Home — tag filtering', () => {
     })
 
     it('applies tag filter AND search together', () => {
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         fireEvent.click(screen.getByRole('button', { name: 'X' }))
         fireEvent.change(screen.getByPlaceholderText('Search collections…'), {
             target: { value: 'Alpha' },
@@ -203,7 +198,7 @@ describe('Home — tag filtering', () => {
             },
         })
 
-        render(<Home />)
+        render(<HomePage collections={collections} />)
         fireEvent.click(screen.getByRole('button', { name: 'Due (1)' }))
 
         expect(screen.getByText('Alpha')).toBeInTheDocument()

--- a/src/routes/collections.$id.tsx
+++ b/src/routes/collections.$id.tsx
@@ -1,30 +1,14 @@
-import { createFileRoute, notFound, Link, useNavigate } from '@tanstack/react-router'
-import { getCollection } from '@/services/challengeService'
-import { TypingGame } from '@/components/features/TypingGame'
-import { ModePicker } from '@/components/features/ModePicker'
-import { SRSAllDoneScreen } from '@/components/features/SRSAllDoneScreen'
-import { SRSProgressView } from '@/components/features/SRSProgressView'
-import { SRSQueuePanel } from '@/components/features/SRSQueuePanel'
-import { useEffect, useMemo } from 'react'
-import { useSRSStore } from '@/store/useSRSStore'
+import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router'
 import {
-    isCustomCollectionId,
-    isValidCustomCollection,
-    toPlayableCollection,
-    useCustomCollectionsStore,
-} from '@/store/useCustomCollectionsStore'
-import { useSessionChallenges } from '@/hooks/useSessionChallenges'
-import { Button } from '@/components/ui/Button'
-import type { Challenge, Collection } from '@/types/challenge'
-
-const EMPTY_CHALLENGES: Challenge[] = []
-
-type CollectionLoaderData =
-    | { kind: 'bundled'; collection: Collection }
-    | { kind: 'custom'; id: string }
+    CollectionGamePage,
+    type CollectionLoaderData,
+    type CollectionSearchState,
+} from '@/components/features/CollectionGamePage'
+import { getCollection } from '@/services/challengeService'
+import { isCustomCollectionId } from '@/store/useCustomCollectionsStore'
 
 export const Route = createFileRoute('/collections/$id')({
-    component: CollectionGamePage,
+    component: CollectionGameRoute,
     loader: async ({ params }) => {
         if (isCustomCollectionId(params.id)) {
             return { kind: 'custom' as const, id: params.id }
@@ -36,7 +20,7 @@ export const Route = createFileRoute('/collections/$id')({
         }
         return { kind: 'bundled' as const, collection }
     },
-    validateSearch: (search: Record<string, unknown>): { questionId?: string | number; mode?: 'normal' | 'srs'; view?: 'progress' } => {
+    validateSearch: (search: Record<string, unknown>): CollectionSearchState => {
         const raw = search.questionId
 
         let questionId: string | number | undefined
@@ -64,193 +48,35 @@ export const Route = createFileRoute('/collections/$id')({
     },
 })
 
-const BackArrow = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="h-6 w-6"
-    >
-        <path d="m15 18-6-6 6-6" />
-    </svg>
-)
-
-export function CollectionGamePage() {
+function CollectionGameRoute() {
     const loaderData = Route.useLoaderData() as CollectionLoaderData
-    const { questionId, mode, view } = Route.useSearch()
+    const search = Route.useSearch()
     const navigate = useNavigate({ from: Route.fullPath })
-    const cards = useSRSStore((s) => s.cards)
-    const recordPlay = useSRSStore((s) => s.recordPlay)
-    const customCollection = useCustomCollectionsStore((s) => (
-        loaderData.kind === 'custom' ? s.collections[loaderData.id] : undefined
-    ))
-    const customHasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
-
-    const collection = useMemo(() => {
-        if (loaderData.kind === 'bundled') {
-            return loaderData.collection
-        }
-
-        if (!customCollection || !isValidCustomCollection(customCollection)) {
-            return undefined
-        }
-
-        return toPlayableCollection(customCollection)
-    }, [customCollection, loaderData])
-    const collectionId = collection?.id
-
-    const allChallenges = collection?.challenges ?? EMPTY_CHALLENGES
-    const challenges = useSessionChallenges({
-        collectionId: collectionId ?? '',
-        mode,
-        allChallenges,
-        cards,
-    })
-
-    useEffect(() => {
-        if (collectionId && (mode === 'srs' || mode === 'normal')) {
-            recordPlay(collectionId)
-        }
-    }, [mode, collectionId, recordPlay])
 
     const goToPicker = () => navigate({ search: () => ({}) })
     const startNormal = () => navigate({ search: () => ({ mode: 'normal' as const }) })
     const startSRS = () => navigate({ search: () => ({ mode: 'srs' as const }) })
     const goToProgress = () => navigate({ search: () => ({ view: 'progress' as const }) })
 
-    if (loaderData.kind === 'custom' && !customHasHydrated) {
-        return (
-            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
-                Loading collection...
-            </main>
-        )
-    }
-
-    if (!collection) {
-        return (
-            <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-4 text-center">
-                <h1 className="text-2xl font-bold">Collection not found</h1>
-                <p className="max-w-sm text-sm text-muted-foreground">
-                    This custom collection is not saved or is not playable on this device.
-                </p>
-                <Link
-                    to="/"
-                    className="rounded-[var(--radius)] border border-border px-3 py-2 text-sm font-medium transition-colors hover:border-primary"
-                >
-                    Home
-                </Link>
-            </main>
-        )
-    }
-
-    // Progress view
-    if (view === 'progress') {
-        return (
-            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
-                <Button
-                    variant="link"
-                    onClick={goToPicker}
-                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
-                    title="Back"
-                >
-                    <BackArrow />
-                    <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
-                </Button>
-                <SRSProgressView collection={collection} onBack={goToPicker} />
-            </main>
-        )
-    }
-
-    // Mode picker — no mode selected yet
-    if (mode === undefined) {
-        return (
-            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
-                <Link
-                    to="/"
-                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-                    title="Back to Home"
-                >
-                    <BackArrow />
-                    <span className="sr-only md:not-sr-only text-sm font-medium">Home</span>
-                </Link>
-                <ModePicker
-                    collection={collection}
-                    onSelectNormal={startNormal}
-                    onSelectSRS={startSRS}
-                    onViewProgress={goToProgress}
-                />
-            </main>
-        )
-    }
-
-    // SRS all-done screen
-    if (mode === 'srs' && challenges.length === 0) {
-        return (
-            <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
-                <Button
-                    variant="link"
-                    onClick={goToPicker}
-                    className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
-                    title="Back"
-                >
-                    <BackArrow />
-                    <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
-                </Button>
-                <SRSAllDoneScreen
-                    collectionId={collection.id}
-                    challenges={collection.challenges ?? []}
-                    onBack={goToPicker}
-                />
-            </main>
-        )
-    }
-
-    // Game
     return (
-        <main className="relative flex min-h-screen flex-col items-center justify-start md:justify-center px-4 pb-4 pt-20 md:p-24 bg-background">
-            <Button
-                variant="link"
-                onClick={goToPicker}
-                className="absolute top-4 left-4 md:top-8 md:left-8 flex items-center gap-2 no-underline"
-                title="Back"
-            >
-                <BackArrow />
-                <span className="sr-only md:not-sr-only text-sm font-medium">Back</span>
-            </Button>
-            <div className="mb-4 text-center">
-                <h2 className="text-xl text-muted-foreground">{collection.title}</h2>
-            </div>
-            <TypingGame
-                key={mode}
-                challenges={challenges}
-                freeInput={collection.freeInput}
-                initialQuestionId={questionId ? String(questionId) : undefined}
-                onQuestionChange={(newId) => {
-                    const numericId = Number(newId)
-                    const isNumeric = !isNaN(numericId) && newId.trim() !== ''
-                    navigate({
-                        search: (prev) => ({
-                            ...prev,
-                            questionId: isNumeric ? numericId : newId,
-                        }),
-                        replace: true,
-                    })
-                }}
-                onFinished={mode === 'srs' ? goToPicker : undefined}
-                srsContext={mode === 'srs' ? { collectionId: collection.id } : undefined}
-            />
-            {mode === 'srs' && (
-                <SRSQueuePanel
-                    collectionId={collection.id}
-                    allChallenges={collection.challenges ?? []}
-                />
-            )}
-        </main>
+        <CollectionGamePage
+            loaderData={loaderData}
+            search={search}
+            onGoToPicker={goToPicker}
+            onStartNormal={startNormal}
+            onStartSRS={startSRS}
+            onGoToProgress={goToProgress}
+            onQuestionChange={(newId) => {
+                const numericId = Number(newId)
+                const isNumeric = !isNaN(numericId) && newId.trim() !== ''
+                navigate({
+                    search: (prev) => ({
+                        ...prev,
+                        questionId: isNumeric ? numericId : newId,
+                    }),
+                    replace: true,
+                })
+            }}
+        />
     )
 }

--- a/src/routes/custom-collections.$id.edit.tsx
+++ b/src/routes/custom-collections.$id.edit.tsx
@@ -1,38 +1,11 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { CollectionEditor } from '@/components/features/CollectionEditor'
-import { useCustomCollectionsStore } from '@/store/useCustomCollectionsStore'
+import { createFileRoute } from '@tanstack/react-router'
+import { EditCustomCollectionPage } from '@/components/features/EditCustomCollectionPage'
 
 export const Route = createFileRoute('/custom-collections/$id/edit')({
-    component: EditCustomCollectionPage,
+    component: EditCustomCollectionRoute,
 })
 
-export function EditCustomCollectionPage() {
+function EditCustomCollectionRoute() {
     const { id } = Route.useParams()
-    const collection = useCustomCollectionsStore((s) => s.collections[id])
-    const hasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
-
-    if (!hasHydrated) {
-        return (
-            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
-                Loading collection…
-            </main>
-        )
-    }
-
-    if (!collection) {
-        return (
-            <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-4 text-center">
-                <h1 className="text-2xl font-bold">Collection not found</h1>
-                <p className="text-sm text-muted-foreground">This custom collection is not saved on this device.</p>
-                <Link
-                    to="/"
-                    className="rounded-[var(--radius)] border border-border px-3 py-2 text-sm font-medium transition-colors hover:border-primary"
-                >
-                    Home
-                </Link>
-            </main>
-        )
-    }
-
-    return <CollectionEditor collection={collection} />
+    return <EditCustomCollectionPage id={id} />
 }

--- a/src/routes/custom-collections.new.tsx
+++ b/src/routes/custom-collections.new.tsx
@@ -1,28 +1,6 @@
-import { createFileRoute, Navigate } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
-import { CustomCollection, useCustomCollectionsStore } from '@/store/useCustomCollectionsStore'
+import { createFileRoute } from '@tanstack/react-router'
+import { NewCustomCollectionPage } from '@/components/features/NewCustomCollectionPage'
 
 export const Route = createFileRoute('/custom-collections/new')({
     component: NewCustomCollectionPage,
 })
-
-export function NewCustomCollectionPage() {
-    const createDraft = useCustomCollectionsStore((s) => s.createDraft)
-    const hasHydrated = useCustomCollectionsStore((s) => s._hasHydrated)
-    const [draft, setDraft] = useState<CustomCollection | null>(null)
-
-    useEffect(() => {
-        if (!hasHydrated || draft) return
-        setDraft(createDraft())
-    }, [createDraft, draft, hasHydrated])
-
-    if (!draft) {
-        return (
-            <main className="flex min-h-screen items-center justify-center bg-background p-4 text-sm text-muted-foreground">
-                {hasHydrated ? 'Creating draft…' : 'Loading collections…'}
-            </main>
-        )
-    }
-
-    return <Navigate to="/custom-collections/$id/edit" params={{ id: draft.id }} replace />
-}

--- a/src/routes/dictionary.tsx
+++ b/src/routes/dictionary.tsx
@@ -1,10 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { DictionaryBrowser } from '@/components/features/DictionaryBrowser'
+import { DictionaryPage } from '@/components/features/DictionaryPage'
 
 export const Route = createFileRoute('/dictionary')({
     component: DictionaryPage,
 })
-
-export function DictionaryPage() {
-    return <DictionaryBrowser />
-}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,10 +1,6 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+import { HomePage } from '@/components/features/HomePage'
 import { getCollections } from '@/services/challengeService'
-import { useHomeCollections } from '@/hooks/useHomeCollections'
-import { IconPlus } from '@/components/ui/icons'
-import { CollectionFilters } from '@/components/features/home/CollectionFilters'
-import { CollectionList } from '@/components/features/home/CollectionList'
-import { SRSQueuePanel } from '@/components/features/SRSQueuePanel'
 
 export const Route = createFileRoute('/')({
     component: Home,
@@ -14,42 +10,7 @@ export const Route = createFileRoute('/')({
     },
 })
 
-export function Home() {
+function Home() {
     const { collections } = Route.useLoaderData()
-    const homeCollections = useHomeCollections(collections)
-
-    return (
-        <main className="flex min-h-screen flex-col items-center justify-center p-4 md:p-24 bg-background">
-            <div className="w-full max-w-4xl">
-                <header className="mb-6">
-                    <p className="mono-label mb-1">collections</p>
-                    <Link
-                        to="/custom-collections/new"
-                        className="mt-3 inline-flex items-center gap-2 rounded-[var(--radius)] border border-border bg-card px-3 py-2 text-sm font-medium transition-colors hover:border-primary hover:bg-[var(--bg2)]"
-                    >
-                        <IconPlus className="h-4 w-4" />
-                        Create collection
-                    </Link>
-
-                    <CollectionFilters
-                        query={homeCollections.query}
-                        onQueryChange={homeCollections.setQuery}
-                        filter={homeCollections.filter}
-                        onFilterChange={homeCollections.setFilter}
-                        totalDue={homeCollections.totalDue}
-                        tags={homeCollections.allTags}
-                        activeTag={homeCollections.activeTag}
-                        onTagClick={homeCollections.handleTagClick}
-                    />
-                </header>
-
-                <CollectionList
-                    isHydrated={homeCollections.isHydrated}
-                    skeletonCollections={homeCollections.skeletonCollections}
-                    collections={homeCollections.visibleCollections}
-                />
-            </div>
-            <SRSQueuePanel />
-        </main>
-    )
+    return <HomePage collections={collections} />
 }


### PR DESCRIPTION
## Summary
- Move exported page components out of TanStack route files so route modules export only Route
- Update route/page tests to import feature page components and keep route wiring coverage on Route.options
- Document the split route-testing convention and stabilize the custom collection deletion e2e persistence assertion

## Verification
- npx vitest run src/routes/__tests__/index.test.tsx src/routes/__tests__/dictionary.test.tsx 'src/routes/__tests__/collections..test.tsx' 'src/routes/__tests__/collections..loader.test.ts'
- npm run lint
- npm run build
- npm run test:e2e

Closes #69