### PR TITLE
test: cover SRS all-done state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ Persisted to IndexedDB via `idb-keyval` under the key `langtype-srs-v1`. Only `c
 |---|---|---|
 | `cards` | `Record<"colId:chalId", SRSCard>` | Per-card SRS state, keyed `collectionId:challengeId` |
 | `lastPlayedAt` | `Record<colId, ms>` | Timestamp of last play per collection, used for home-page sort |
-| `_hasHydrated` | `boolean` | Set to `true` after IndexedDB rehydration; gates sort order and due counts to prevent flicker |
+| `_hasHydrated` | `boolean` | Set to `true` after IndexedDB rehydration; gates sort order, due counts, and direct SRS session startup to prevent stale empty-store decisions |
 
 **`SRSCard` fields**: `interval` (days), `repetitions` (consecutive correct), `easeFactor` (starts 2.5, min 1.3), `nextReviewAt` (ms; 0 = new card), `lastReviewedAt` (ms; 0 = never reviewed).
 

--- a/docs/product-behaviour.md
+++ b/docs/product-behaviour.md
@@ -45,6 +45,8 @@ All state lives in URL search params. The page renders one of four views dependi
 
 Bundled collections are loaded by the route loader. Local custom collection deep links (`/collections/custom_*`) wait for IndexedDB-backed custom collection storage to hydrate before deciding whether the collection exists. If the custom collection is not saved on the current device or is still a draft with no playable challenges, the collection route shows a local "Collection not found" state instead of the root 404.
 
+Direct SRS links wait for the SRS store to hydrate before building the session queue. This prevents persisted future-scheduled cards from being treated as new cards during page-load hydration.
+
 Back button always navigates to `?` (clears params) → mode picker. Retry state is reset via a `useEffect` watching `mode`, not before `navigate()`, to avoid a transient render where `mode=srs` + `retryCount=0` would flash the all-done screen.
 
 ## SRS Session Flow

--- a/e2e/srs-all-done.spec.ts
+++ b/e2e/srs-all-done.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const COLLECTION_ID = 'netzwerk_neu_a1_k1_nomen_plural'
+const COLLECTION_URL = `/collections/${COLLECTION_ID}`
+const COLLECTION_TITLE = /Netzwerk Neu A1.*Kapitel 1: Artikel \+ Plural/
+const CHALLENGE_IDS = Array.from({ length: 26 }, (_, index) => String(index + 1))
+
+interface SeedSRSPayload {
+    collectionId: string
+    challengeIds: string[]
+    now: number
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+        localStorage.setItem('lt_theme', 'warm')
+    })
+})
+
+function seedFutureSRSCardsInBrowser({ collectionId, challengeIds, now }: SeedSRSPayload) {
+    return new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open('keyval-store', 1)
+
+        openRequest.onupgradeneeded = () => {
+            openRequest.result.createObjectStore('keyval')
+        }
+
+        openRequest.onerror = () => reject(openRequest.error)
+
+        openRequest.onsuccess = () => {
+            const db = openRequest.result
+            const transaction = db.transaction('keyval', 'readwrite')
+            const store = transaction.objectStore('keyval')
+            const nextReviewAt = now + 24 * 60 * 60 * 1000
+            const cards: Record<string, {
+                collectionId: string
+                challengeId: string
+                interval: number
+                repetitions: number
+                easeFactor: number
+                nextReviewAt: number
+                lastReviewedAt: number
+            }> = {}
+
+            for (const challengeId of challengeIds) {
+                cards[`${collectionId}:${challengeId}`] = {
+                    collectionId,
+                    challengeId,
+                    interval: 1,
+                    repetitions: 1,
+                    easeFactor: 2.6,
+                    nextReviewAt,
+                    lastReviewedAt: now,
+                }
+            }
+
+            store.put(JSON.stringify({
+                state: {
+                    cards,
+                    lastPlayedAt: {},
+                },
+                version: 1,
+            }), 'langtype-srs-v1')
+
+            transaction.oncomplete = () => {
+                db.close()
+                resolve()
+            }
+            transaction.onerror = () => reject(transaction.error)
+            transaction.onabort = () => reject(transaction.error)
+        }
+    })
+}
+
+async function seedFutureSRSCards(page: Page) {
+    await page.goto('/')
+
+    await page.evaluate(seedFutureSRSCardsInBrowser, {
+        collectionId: COLLECTION_ID,
+        challengeIds: CHALLENGE_IDS,
+        now: Date.now(),
+    })
+}
+
+test('shows all-done state when SRS has no due cards', async ({ page }) => {
+    await seedFutureSRSCards(page)
+
+    await page.goto(`${COLLECTION_URL}?mode=srs`)
+
+    await expect(page.getByRole('heading', { name: 'All caught up!' })).toBeVisible()
+    await expect(page.getByText('Next cards due in 24 hours.')).toBeVisible()
+    await expect(page.getByText('Name', { exact: true })).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Back to collection' }).click()
+
+    await expect(page).toHaveURL(new RegExp(`${COLLECTION_URL}$`))
+    await expect(page.getByRole('heading', { name: COLLECTION_TITLE })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Spaced Repetition\s+Next review in 24h/ })).toBeDisabled()
+})

--- a/src/components/features/CollectionGamePage.tsx
+++ b/src/components/features/CollectionGamePage.tsx
@@ -65,6 +65,7 @@ export function CollectionGamePage({
 }: Props) {
     const { questionId, mode, view } = search
     const cards = useSRSStore((s) => s.cards)
+    const srsHasHydrated = useSRSStore((s) => s._hasHydrated)
     const recordPlay = useSRSStore((s) => s.recordPlay)
     const customCollection = useCustomCollectionsStore((s) => (
         loaderData.kind === 'custom' ? s.collections[loaderData.id] : undefined
@@ -90,6 +91,7 @@ export function CollectionGamePage({
         mode,
         allChallenges,
         cards,
+        srsHasHydrated,
     })
 
     useEffect(() => {
@@ -157,6 +159,14 @@ export function CollectionGamePage({
                     onSelectSRS={onStartSRS}
                     onViewProgress={onGoToProgress}
                 />
+            </main>
+        )
+    }
+
+    if (mode === 'srs' && !srsHasHydrated) {
+        return (
+            <main className="relative flex min-h-screen flex-col items-center justify-center px-4 bg-background text-sm text-muted-foreground">
+                Loading SRS...
             </main>
         )
     }

--- a/src/hooks/__tests__/useSessionChallenges.test.ts
+++ b/src/hooks/__tests__/useSessionChallenges.test.ts
@@ -32,6 +32,7 @@ describe('useSessionChallenges', () => {
                 mode: 'srs',
                 allChallenges: challenges,
                 cards: { 'test:2': reviewedCard('test', '2') },
+                srsHasHydrated: true,
             })
         )
 
@@ -46,6 +47,7 @@ describe('useSessionChallenges', () => {
                     mode: 'srs',
                     allChallenges: challenges,
                     cards,
+                    srsHasHydrated: true,
                 }),
             {
                 initialProps: {
@@ -67,6 +69,29 @@ describe('useSessionChallenges', () => {
         expect(result.current).toHaveLength(3)
     })
 
+    it('does not replace a normal session when SRS hydration completes', () => {
+        const { result, rerender } = renderHook(
+            ({ srsHasHydrated }: { srsHasHydrated: boolean }) =>
+                useSessionChallenges({
+                    collectionId: 'test',
+                    mode: 'normal',
+                    allChallenges: challenges,
+                    cards: {},
+                    srsHasHydrated,
+                }),
+            {
+                initialProps: {
+                    srsHasHydrated: false,
+                },
+            }
+        )
+        const initialChallenges = result.current
+
+        rerender({ srsHasHydrated: true })
+
+        expect(result.current).toBe(initialChallenges)
+    })
+
     it('starts a fresh snapshot when the mode changes', () => {
         const { result, rerender } = renderHook(
             ({ mode }: { mode: SessionMode }) =>
@@ -77,6 +102,7 @@ describe('useSessionChallenges', () => {
                     cards: {
                         'test:2': reviewedCard('test', '2'),
                     },
+                    srsHasHydrated: true,
                 }),
             {
                 initialProps: {
@@ -90,5 +116,34 @@ describe('useSessionChallenges', () => {
         rerender({ mode: 'srs' })
 
         expect(result.current.map((challenge) => challenge.id).sort()).toEqual(['1', '3'])
+    })
+
+    it('waits for SRS hydration before snapshotting a direct SRS session', () => {
+        const futureCards = {
+            'test:1': reviewedCard('test', '1'),
+            'test:2': reviewedCard('test', '2'),
+            'test:3': reviewedCard('test', '3'),
+        }
+        const { result, rerender } = renderHook(
+            ({ srsHasHydrated }: { srsHasHydrated: boolean }) =>
+                useSessionChallenges({
+                    collectionId: 'test',
+                    mode: 'srs',
+                    allChallenges: challenges,
+                    cards: futureCards,
+                    srsHasHydrated,
+                }),
+            {
+                initialProps: {
+                    srsHasHydrated: false,
+                },
+            }
+        )
+
+        expect(result.current).toHaveLength(0)
+
+        rerender({ srsHasHydrated: true })
+
+        expect(result.current).toHaveLength(0)
     })
 })

--- a/src/hooks/useSessionChallenges.ts
+++ b/src/hooks/useSessionChallenges.ts
@@ -11,6 +11,7 @@ interface UseSessionChallengesProps {
     mode: CollectionMode
     allChallenges: Challenge[]
     cards: Record<string, SRSCard>
+    srsHasHydrated: boolean
 }
 
 export function useSessionChallenges({
@@ -18,13 +19,15 @@ export function useSessionChallenges({
     mode,
     allChallenges,
     cards,
+    srsHasHydrated,
 }: UseSessionChallengesProps) {
     const cardsRef = useRef(cards)
-    const sessionRef = useRef({ collectionId, mode, allChallenges })
+    const srsHydrationKey = mode === 'srs' ? srsHasHydrated : true
+    const sessionRef = useRef({ collectionId, mode, allChallenges, srsHydrationKey })
     cardsRef.current = cards
 
     const [challenges, setChallenges] = useState(() =>
-        buildSessionChallenges(collectionId, mode, allChallenges, cards)
+        buildSessionChallenges(collectionId, mode, allChallenges, cards, srsHasHydrated)
     )
 
     useEffect(() => {
@@ -32,14 +35,15 @@ export function useSessionChallenges({
         if (
             previousSession.collectionId === collectionId &&
             previousSession.mode === mode &&
-            previousSession.allChallenges === allChallenges
+            previousSession.allChallenges === allChallenges &&
+            previousSession.srsHydrationKey === srsHydrationKey
         ) {
             return
         }
 
-        sessionRef.current = { collectionId, mode, allChallenges }
-        setChallenges(buildSessionChallenges(collectionId, mode, allChallenges, cardsRef.current))
-    }, [collectionId, mode, allChallenges])
+        sessionRef.current = { collectionId, mode, allChallenges, srsHydrationKey }
+        setChallenges(buildSessionChallenges(collectionId, mode, allChallenges, cardsRef.current, srsHasHydrated))
+    }, [collectionId, mode, allChallenges, srsHasHydrated, srsHydrationKey])
 
     return challenges
 }
@@ -49,7 +53,10 @@ function buildSessionChallenges(
     mode: CollectionMode,
     allChallenges: Challenge[],
     cards: Record<string, SRSCard>,
+    srsHasHydrated: boolean,
 ) {
+    if (mode === 'srs' && !srsHasHydrated) return []
+
     if (mode === 'srs') {
         const dueIds = getDueChallengeIds(collectionId, allChallenges.map((c) => c.id), cards)
         return shuffleArray(allChallenges.filter((c) => dueIds.includes(c.id)))

--- a/src/routes/__tests__/collections.$id.test.tsx
+++ b/src/routes/__tests__/collections.$id.test.tsx
@@ -159,6 +159,16 @@ describe('CollectionGamePage', () => {
         expect(screen.queryByRole('heading', { name: 'All caught up!' })).not.toBeInTheDocument()
     })
 
+    it('waits for SRS hydration before rendering a direct SRS session', () => {
+        mockSRSState._hasHydrated = false
+
+        renderPage({ search: { questionId: undefined, mode: 'srs' } })
+
+        expect(screen.getByText('Loading SRS...')).toBeInTheDocument()
+        expect(screen.queryByRole('heading', { name: 'All caught up!' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('textbox', { name: 'Translation answer' })).not.toBeInTheDocument()
+    })
+
     it('navigates when the real game advances to the next question', () => {
         renderPage()
 


### PR DESCRIPTION
## Summary
- gate direct SRS session startup on SRS store hydration
- add e2e coverage for the SRS all-done deep-link state
- document the hydration gate for direct SRS links

## Verification
- npx vitest run src/hooks/__tests__/useSessionChallenges.test.ts
- npx vitest run 'src/routes/__tests__/collections..test.tsx'
- npx playwright test e2e/srs-all-done.spec.ts
- npm run lint
- npm run build

Closes #33